### PR TITLE
fix: point Node link to Node, rather than Python, download link

### DIFF
--- a/site/viamguides/src/drive-rover-ts/drive-rover-ts.md
+++ b/site/viamguides/src/drive-rover-ts/drive-rover-ts.md
@@ -30,7 +30,7 @@ Drive a rover in a square using the Viam TypeScript SDK.
 
 - A Linux, macOS or Windows computer that can run SDK code
 - [VS Code](https://code.visualstudio.com/download) installed, or your preferred code editor
-- [Node](https://www.python.org/downloads/) installed
+- [Node](https://nodejs.org/en/download) installed
 
 ### What You’ll Build
 


### PR DESCRIPTION
Simple fix I found while completing the Drive a Rover with TS workshop.